### PR TITLE
feat(49): http service, auth header, redux-persist

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{ts,tsx,js,jsx,json}]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/packages/web/.eslintrc.js
+++ b/packages/web/.eslintrc.js
@@ -30,7 +30,7 @@ module.exports = {
     'import/prefer-default-export': 'off',
     'import/no-unresolved': [
       'error',
-      { ignore: ['elements', 'components', 'pages', 'store', 'config'] }
+      { ignore: ['elements', 'components', 'pages', 'store', 'config', 'services'] }
     ],
     'react/jsx-filename-extension': [
       'warn',

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,6 +36,7 @@
     "react-scripts": "3.4.1",
     "redux": "^4.0.5",
     "redux-devtools-extension": "^2.13.8",
+    "redux-persist": "^6.0.0",
     "redux-saga": "^1.1.3",
     "reselect": "^4.0.0",
     "typescript": "~3.7.2"

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -2,23 +2,26 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { ConnectedRouter } from 'connected-react-router';
 import { Route, Switch } from 'react-router-dom';
-import store, { history } from 'store';
+import { PersistGate } from 'redux-persist/integration/react';
+import store, { history, persistor } from 'store';
 import { Home, SignIn, SignUp, PasswordReset, Profile, SignOut, EmailConfirm } from 'pages';
 import './custom.scss';
 
 const App = () => (
   <Provider store={store}>
-    <ConnectedRouter history={history}>
-      <Switch>
-        <Route path="/signin" component={SignIn} />
-        <Route path="/signout" component={SignOut} />
-        <Route path="/profile" component={Profile} />
-        <Route path="/signup" component={SignUp} />
-        <Route path="/reset" component={PasswordReset} />
-        <Route path="/confirm" component={EmailConfirm} />
-        <Route path="/" component={Home} />
-      </Switch>
-    </ConnectedRouter>
+    <PersistGate persistor={persistor}>
+      <ConnectedRouter history={history}>
+        <Switch>
+          <Route path="/signin" component={SignIn} />
+          <Route path="/signout" component={SignOut} />
+          <Route path="/profile" component={Profile} />
+          <Route path="/signup" component={SignUp} />
+          <Route path="/reset" component={PasswordReset} />
+          <Route path="/confirm" component={EmailConfirm} />
+          <Route path="/" component={Home} />
+        </Switch>
+      </ConnectedRouter>
+    </PersistGate>
   </Provider>
 );
 

--- a/packages/web/src/components/Header/Header.tsx
+++ b/packages/web/src/components/Header/Header.tsx
@@ -7,7 +7,7 @@ import './styles.scss';
 import logo from './logo.svg';
 
 export const Header = () => {
-  const { token, firstName = '', lastName = '' } = useSelector(getAuth);
+  const { isAuthenticated, firstName = '', lastName = '' } = useSelector(getAuth);
 
   return (
     <header>
@@ -34,7 +34,7 @@ export const Header = () => {
           </Nav.Item>
         </Nav>
         <Nav>
-          {token ? (
+          {isAuthenticated ? (
             <>
               <Nav.Item>{`${firstName} ${lastName}`.trim()}</Nav.Item>
               <NavLink to="/signout">Sign Out</NavLink>

--- a/packages/web/src/pages/Profile/Profile.tsx
+++ b/packages/web/src/pages/Profile/Profile.tsx
@@ -6,12 +6,13 @@ import { getAuth } from 'store/auth/selectors';
 
 export const Profile = () => {
   const dispatch = useDispatch();
-  const { token, firstName = '', lastName = '', email } = useSelector(getAuth);
+  const { isAuthenticated, firstName = '', lastName = '', email } = useSelector(getAuth);
   const name = `${firstName} ${lastName}`.trim();
 
   useEffect(() => {
-    if (!token) dispatch(push('/signin'));
-  }, [token, dispatch]);
+    if (!isAuthenticated) dispatch(push('/signin'));
+  }, [isAuthenticated, dispatch]);
+
   return (
     <Container>
       <Header />

--- a/packages/web/src/pages/SignIn/styles.scss
+++ b/packages/web/src/pages/SignIn/styles.scss
@@ -5,5 +5,5 @@
   flex-direction: column;
   align-items: center;
   padding: 0;
-  justify-content: start;
+  justify-content: flex-start;
 }

--- a/packages/web/src/services/http/http.service.ts
+++ b/packages/web/src/services/http/http.service.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+import { api } from 'config';
+
+export const http = axios.create({
+  baseURL: api,
+})
+
+http.interceptors.request.use(
+  config => {
+    const token = localStorage.getItem('authToken');
+    console.log('token', token);
+    if (token) {
+      config.headers.authorization = token; // eslint-disable-line no-param-reassign
+    }
+    return config;
+  },
+  error => Promise.reject(error),
+);

--- a/packages/web/src/services/http/index.ts
+++ b/packages/web/src/services/http/index.ts
@@ -1,0 +1,1 @@
+export * from './http.service';

--- a/packages/web/src/services/index.ts
+++ b/packages/web/src/services/index.ts
@@ -1,0 +1,1 @@
+export * from './http';

--- a/packages/web/src/store/auth/actions.ts
+++ b/packages/web/src/store/auth/actions.ts
@@ -1,6 +1,6 @@
 export interface AuthState {
   isLoading: boolean;
-  token: string | null;
+  isAuthenticated: boolean | null;
   id: number | null;
   firstName: string | null;
   lastName: string | null;
@@ -40,7 +40,6 @@ interface AuthLoginSuccessPayload {
   firstName: string;
   lastName: string;
   email: string;
-  token: string;
 }
 
 export interface AuthLogin {

--- a/packages/web/src/store/auth/reducer.test.ts
+++ b/packages/web/src/store/auth/reducer.test.ts
@@ -73,6 +73,7 @@ describe('store/auth/reducer', () => {
     actions.forEach((action) => {
       describe(action, () => {
         it('should handle succesfull authantication', () => {
+          const { token, ...userData } = authResult; // eslint-disable-line @typescript-eslint/no-unused-vars
           expect(
             authReducer(
               { ...initialState, isLoading: true },
@@ -83,7 +84,8 @@ describe('store/auth/reducer', () => {
             )
           ).toEqual({
             ...initialState,
-            ...authResult,
+            ...userData,
+            isAuthenticated: true,
           });
         });
       });

--- a/packages/web/src/store/auth/reducer.ts
+++ b/packages/web/src/store/auth/reducer.ts
@@ -24,7 +24,7 @@ import {
 } from './actions';
 
 export const initialState: AuthState = {
-  token: null,
+  isAuthenticated: false,
   id: null,
   firstName: null,
   lastName: null,
@@ -53,14 +53,14 @@ export function authReducer(
     case AUTH_EMAIL_CONFIRM_SUCCESS:
     case AUTH_FACEBOOK_SUCCESS:
     case AUTH_LOGIN_SUCCESS: {
-      const { id, firstName, lastName, email, token } = action.payload;
+      const { id, firstName, lastName, email } = action.payload;
       return {
         ...state,
+        isAuthenticated: true,
         id,
         firstName,
         lastName,
         email,
-        token,
         isLoading: false,
       };
     }
@@ -102,6 +102,7 @@ export function authReducer(
     case AUTH_LOGOUT:
       return {
         ...initialState,
+        isAuthenticated: false,
       };
 
     case LOCATION_CHANGE:

--- a/packages/web/src/store/auth/sagas/authEmailConfirm.saga.ts
+++ b/packages/web/src/store/auth/sagas/authEmailConfirm.saga.ts
@@ -1,6 +1,5 @@
 import { call, put, takeLatest } from 'redux-saga/effects'
-import axios from 'axios';
-import { api } from 'config';
+import { http } from 'services';
 import { push } from 'connected-react-router';
 import {
   AUTH_EMAIL_CONFIRM,
@@ -22,12 +21,10 @@ function* handle(action: AuthEmailConfirm) {
   }
 
   try {
-    const result = yield call(axios.post, `${api}/auth/confirm`,
-      { emailVerificationToken }
-    );
+    const result = yield call(http.post, '/auth/confirm', { emailVerificationToken });
     yield put({
       type: AUTH_EMAIL_CONFIRM_SUCCESS,
-      payload: result.data
+      payload: result.data,
     });
     yield put(push('/profile'));
   } catch (e) {

--- a/packages/web/src/store/auth/sagas/authFacebook.saga.test.ts
+++ b/packages/web/src/store/auth/sagas/authFacebook.saga.test.ts
@@ -1,7 +1,7 @@
 import { expectSaga } from 'redux-saga-test-plan';
-import { push } from 'connected-react-router';
-import axios from 'axios';
 import { call } from 'redux-saga/effects';
+import { push } from 'connected-react-router';
+import { http } from 'services';
 
 import { getEnvironment } from 'config';
 import {
@@ -11,8 +11,10 @@ import {
 } from '../actions';
 import { authFacebook } from './authFacebook.saga';
 
-jest.mock('axios', () => ({
-  post: jest.fn(),
+jest.mock('services', () => ({
+  http: {
+    post: jest.fn(),
+  }
 }));
 
 jest.mock('connected-react-router', () => ({
@@ -32,12 +34,12 @@ describe('system/authFacebook', () => {
 
   it('should call api', () => {
     jest
-      .spyOn(axios, 'post')
+      .spyOn(http, 'post')
       .mockImplementationOnce(() => Promise.resolve({ data }));
 
     return expectSaga(authFacebook)
       .provide([[call(getEnvironment), { api }]])
-      .call(axios.post, `${api}/auth/facebook`, { access_token: accessToken })
+      .call(http.post, '/auth/facebook', { access_token: accessToken })
       .put({
         type: AUTH_FACEBOOK_SUCCESS,
         payload: data,
@@ -51,7 +53,7 @@ describe('system/authFacebook', () => {
   });
 
   it('should hanlde error', () => {
-    jest.spyOn(axios, 'post').mockImplementationOnce(() =>
+    jest.spyOn(http, 'post').mockImplementationOnce(() =>
       Promise.reject({
         response: {
           data: {

--- a/packages/web/src/store/auth/sagas/authFacebook.saga.ts
+++ b/packages/web/src/store/auth/sagas/authFacebook.saga.ts
@@ -1,8 +1,6 @@
 import { takeLatest, call, put } from 'redux-saga/effects';
 import { push } from 'connected-react-router';
-import axios from 'axios';
-
-import { getEnvironment } from 'config';
+import { http } from 'services';
 
 import {
   AUTH_FACEBOOK_ERROR,
@@ -13,9 +11,8 @@ import {
 
 function* handle(action: AuthFacebook) {
   const { accessToken } = action.payload;
-  const { api } = yield call(getEnvironment);
   try {
-    const result = yield call(axios.post, `${api}/auth/facebook`, {
+    const result = yield call(http.post, '/auth/facebook', {
       access_token: accessToken,
     });
     yield put({

--- a/packages/web/src/store/auth/sagas/authLogin.saga.ts
+++ b/packages/web/src/store/auth/sagas/authLogin.saga.ts
@@ -1,7 +1,6 @@
 import { takeLatest, call, put } from 'redux-saga/effects';
 import { push } from 'connected-react-router';
-import axios from 'axios';
-import { api } from 'config';
+import { http } from 'services';
 import {
   AUTH_LOGIN,
   AUTH_LOGIN_ERROR,
@@ -12,13 +11,15 @@ import {
 function* handle(action: AuthLogin) {
   const { email, password } = action.payload;
   try {
-    const result = yield call(axios.post, `${api}/auth/login`, {
+    const result = yield call(http.post, '/auth/login', {
       email,
       password
     });
+    const { data: { token, ...userData } } =  result;
+    yield call([localStorage, localStorage.setItem], 'authToken', token);
     yield put({
       type: AUTH_LOGIN_SUCCESS,
-      payload: result.data
+      payload: userData
     });
     yield put(push('/profile'));
   } catch (e) {

--- a/packages/web/src/store/auth/sagas/authLogout.saga.ts
+++ b/packages/web/src/store/auth/sagas/authLogout.saga.ts
@@ -1,0 +1,14 @@
+import { takeLatest, call } from 'redux-saga/effects';
+import { AUTH_LOGOUT } from '../actions';
+
+function* handle() {
+  try {
+    yield call([localStorage, localStorage.clear]);
+  } catch (e) {
+    yield call(console.log, 'log', e);
+  }
+}
+
+export function* authLogoutSaga() {
+  yield takeLatest(AUTH_LOGOUT, handle);
+}

--- a/packages/web/src/store/auth/sagas/authRegister.saga.test.ts
+++ b/packages/web/src/store/auth/sagas/authRegister.saga.test.ts
@@ -1,6 +1,5 @@
 import { expectSaga } from 'redux-saga-test-plan';
-import axios from 'axios';
-import { environments } from 'config';
+import { http } from 'services';
 import {
   AUTH_REGISTER,
   AUTH_REGISTER_SUCCESS,
@@ -8,8 +7,10 @@ import {
 } from '../actions';
 import { authRegisterSaga } from './authRegister.saga';
 
-jest.mock('axios', () => ({
-  post: jest.fn()
+jest.mock('services', () => ({
+  http: {
+    post: jest.fn()
+  }
 }));
 
 jest.mock('connected-react-router', () => ({
@@ -26,11 +27,11 @@ describe('system/authRegisterSaga', () => {
   };
   it('should call api', () => {
     jest
-      .spyOn(axios, 'post')
+      .spyOn(http, 'post')
       .mockImplementationOnce(() => Promise.resolve({ ...data }));
 
     return expectSaga(authRegisterSaga)
-      .call(axios.post, `${environments.local.api}/auth/register`, {
+      .call(http.post, '/auth/register', {
         ...data
       })
       .put({
@@ -49,7 +50,7 @@ describe('system/authRegisterSaga', () => {
   });
 
   it('should hanlde error', () => {
-    jest.spyOn(axios, 'post').mockImplementationOnce(() =>
+    jest.spyOn(http, 'post').mockImplementationOnce(() =>
       Promise.reject({
         response: {
           data: {

--- a/packages/web/src/store/auth/sagas/authRegister.saga.ts
+++ b/packages/web/src/store/auth/sagas/authRegister.saga.ts
@@ -1,6 +1,5 @@
 import { call, takeLatest, put } from 'redux-saga/effects';
-import axios from 'axios';
-import { api } from 'config';
+import { http } from 'services';
 import {
   AUTH_REGISTER,
   AUTH_REGISTER_SUCCESS,
@@ -12,7 +11,7 @@ function* handle(action: AuthRegister) {
   const { email, password, firstName, lastName } = action.payload;
 
   try {
-    yield call(axios.post, `${api}/auth/register`, {
+    yield call(http.post, '/auth/register', {
       email,
       password,
       firstName,

--- a/packages/web/src/store/auth/sagas/authResetPassword.saga.test.ts
+++ b/packages/web/src/store/auth/sagas/authResetPassword.saga.test.ts
@@ -1,6 +1,5 @@
 import { expectSaga } from 'redux-saga-test-plan';
-import axios from 'axios';
-import { environments } from 'config';
+import { http } from 'services';
 import {
   AUTH_RESET_PASSWORD,
   AUTH_RESET_PASSWORD_SUCCESS,
@@ -8,8 +7,10 @@ import {
 } from '../actions';
 import { authResetPasswordSaga } from './authResetPassword.saga';
 
-jest.mock('axios', () => ({
-  post: jest.fn()
+jest.mock('services', () => ({
+  http: {
+    post: jest.fn()
+  }
 }));
 
 jest.mock('connected-react-router', () => ({
@@ -18,10 +19,10 @@ jest.mock('connected-react-router', () => ({
 
 describe('authResetPasswordSaga', () => {
   it('should call api', () => {
-    jest.spyOn(axios, 'post').mockImplementationOnce(() => Promise.resolve({}));
+    jest.spyOn(http, 'post').mockImplementationOnce(() => Promise.resolve({}));
 
     return expectSaga(authResetPasswordSaga)
-      .call(axios.post, `${environments.local.api}/auth/password-reset`, {
+      .call(http.post, '/auth/password-reset', {
         email: 'admin@admin.com',
       })
       .put({
@@ -39,7 +40,7 @@ describe('authResetPasswordSaga', () => {
   });
 
   it('should handle error', () => {
-    jest.spyOn(axios, 'post').mockImplementationOnce(() =>
+    jest.spyOn(http, 'post').mockImplementationOnce(() =>
       Promise.reject({
         response: {
           data: {

--- a/packages/web/src/store/auth/sagas/authResetPassword.saga.ts
+++ b/packages/web/src/store/auth/sagas/authResetPassword.saga.ts
@@ -1,6 +1,5 @@
 import { call, takeLatest, put } from 'redux-saga/effects';
-import axios from 'axios';
-import { api } from 'config';
+import { http } from 'services';
 import {
   AUTH_RESET_PASSWORD,
   AUTH_RESET_PASSWORD_SUCCESS,
@@ -12,7 +11,7 @@ function* handle(action: AuthResetPassword) {
   const { email } = action.payload;
 
   try {
-    yield call(axios.post, `${api}/auth/password-reset`, { email });
+    yield call(http.post, '/auth/password-reset', { email });
     yield put({
       type: AUTH_RESET_PASSWORD_SUCCESS,
       payload: {

--- a/packages/web/src/store/auth/sagas/authUpdatePassword.saga.test.ts
+++ b/packages/web/src/store/auth/sagas/authUpdatePassword.saga.test.ts
@@ -1,11 +1,12 @@
 import { expectSaga } from 'redux-saga-test-plan';
-import axios from 'axios';
-import { environments } from 'config';
+import { http } from 'services'
 import { AUTH_UPDATE_PASSWORD, AUTH_UPDATE_PASSWORD_SUCCESS, AUTH_UPDATE_PASSWORD_ERROR } from '../actions';
 import { authUpdatePasswordSaga } from './authUpdatePassword.saga';
 
-jest.mock('axios', () => ({
-  post: jest.fn()
+jest.mock('services', () => ({
+  http: {
+    post: jest.fn()
+  }
 }));
 
 jest.mock('connected-react-router', () => ({
@@ -14,12 +15,12 @@ jest.mock('connected-react-router', () => ({
 
 describe('authUpdatePassword', () => {
   it('should call api', () => {
-    jest.spyOn(axios, 'post').mockImplementationOnce(() =>
+    jest.spyOn(http, 'post').mockImplementationOnce(() =>
       Promise.resolve({})
     );
 
     return expectSaga(authUpdatePasswordSaga)
-      .call(axios.post, `${environments.local.api}/auth/password-update`, {
+      .call(http.post, '/auth/password-update', {
         passwordResetToken: 'TOKEN',
         password: 'password'
       })
@@ -37,7 +38,7 @@ describe('authUpdatePassword', () => {
   });
 
   it('should handle error', () => {
-    jest.spyOn(axios, 'post').mockImplementationOnce(() =>
+    jest.spyOn(http, 'post').mockImplementationOnce(() =>
       Promise.reject({
         response: {
           data: {

--- a/packages/web/src/store/auth/sagas/authUpdatePassword.saga.ts
+++ b/packages/web/src/store/auth/sagas/authUpdatePassword.saga.ts
@@ -1,18 +1,17 @@
 import { call, takeLatest, put } from 'redux-saga/effects';
-import axios from 'axios';
-import { api } from 'config';
+import { http } from 'services';
 import {
   AUTH_UPDATE_PASSWORD,
   AUTH_UPDATE_PASSWORD_SUCCESS,
   AUTH_UPDATE_PASSWORD_ERROR,
-  AuthUpdatePassword
+  AuthUpdatePassword,
 } from '../actions';
 
 function* handle(action: AuthUpdatePassword) {
   const { token, password } = action.payload;
 
   try {
-    yield call(axios.post, `${api}/auth/password-update`, {
+    yield call(http.post, '/auth/password-update', {
       passwordResetToken: token,
       password
     });

--- a/packages/web/src/store/auth/sagas/index.ts
+++ b/packages/web/src/store/auth/sagas/index.ts
@@ -1,4 +1,5 @@
 export * from './authLogin.saga';
+export * from './authLogout.saga';
 export * from './authRegister.saga';
 export * from './authResetPassword.saga';
 export * from './authUpdatePassword.saga';

--- a/packages/web/src/store/index.ts
+++ b/packages/web/src/store/index.ts
@@ -7,6 +7,8 @@ import {
   routerMiddleware
 } from 'connected-react-router';
 import { createBrowserHistory } from 'history';
+import { persistReducer, persistStore } from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
 import { AuthState, authReducer } from './auth';
 import { rootSaga } from './rootSaga';
 
@@ -18,16 +20,20 @@ export interface AppState {
 export const history = createBrowserHistory();
 const sagaMiddleware = createSagaMiddleware();
 
+const authPersistConfig = { key: 'auth', storage, blacklist: ['isLoading', 'info', 'error'] };
+
 const store = createStore(
   combineReducers({
     router: connectRouter(history),
-    auth: authReducer
+    auth: persistReducer(authPersistConfig, authReducer),
   }),
   composeWithDevTools(
     applyMiddleware(routerMiddleware(history), sagaMiddleware)
-  )
+  ),
 );
 
 export default store;
+
+export const persistor = persistStore(store);
 
 sagaMiddleware.run(rootSaga);

--- a/packages/web/src/store/rootSaga.ts
+++ b/packages/web/src/store/rootSaga.ts
@@ -1,6 +1,7 @@
 import { all } from 'redux-saga/effects';
 import {
   authLoginSaga,
+  authLogoutSaga,
   authRegisterSaga,
   authResetPasswordSaga,
   authUpdatePasswordSaga,
@@ -11,6 +12,7 @@ import {
 export function* rootSaga() {
   yield all([
     authLoginSaga(),
+    authLogoutSaga(),
     authRegisterSaga(),
     authResetPasswordSaga(),
     authUpdatePasswordSaga(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -13956,6 +13956,11 @@ redux-devtools-extension@^2.13.8:
   resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz#37b982688626e5e4993ff87220c9bbb7cd2d96e1"
   integrity sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux-saga-test-plan@^4.0.0-rc.3:
   version "4.0.0-rc.3"
   resolved "https://registry.yarnpkg.com/redux-saga-test-plan/-/redux-saga-test-plan-4.0.0-rc.3.tgz#bde05527202be652859e68d15cdabe79ffa7509a"


### PR DESCRIPTION
 * move axios api calls to a separate http service
 * configure axios instance with a baseUrl
 * add axios interceptor to send Auth header to api if it's available, all requests
 * move token in localStorage
 * add redux-persist to persist other user data on page reload
 * re-write tests where axios is mocked directly
 * add .editorconfig to share editor settings between developers