### PR TITLE
feat(56): separate scripts to run devServer against dev and local API, over HTTP and HTTPS

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,8 +3,12 @@
   "version": "0.0.1",
   "scripts": {
     "start": "cross-env PORT=8080 react-scripts start",
+    "start:https": "cross-env HTTPS=true PORT=4430 react-scripts start",
+    "start:local": "cross-env PORT=8081 react-scripts start",
+    "start:local:https": "cross-env HTTPS=true PORT=4431 react-scripts start",
     "build": "react-scripts build",
-    "eject": "react-scripts eject",
+    "serve": "node server/index.js",
+    "build:serve": "yall build serve",
     "test": "react-scripts test --watchAll=false",
     "test:watch": "react-scripts test",
     "test:coverage": "npm run test -- --coverage",
@@ -17,8 +21,7 @@
     "cy:run": "cypress run",
     "cy:run:smoke": "cypress run --spec=cypress/integration/smoke/*",
     "audit:ci": "yarn-audit-ci",
-    "serve": "node server/index.js",
-    "build:serve": "yall build serve"
+    "eject": "react-scripts eject"
   },
   "dependencies": {
     "axios": "^0.19.2",

--- a/packages/web/src/config/environment.ts
+++ b/packages/web/src/config/environment.ts
@@ -1,15 +1,30 @@
 export const environments = {
-  local: {
+  local: { // local devServer@HTTP using dev env API, started using `yarn start`
     protocol: 'http:',
     host: 'localhost:8080',
     api: 'http://croton.cf:3000/api',
   },
-  localServer: {
+  localHttps: { // local devServer@HTTPS using dev env API, started using `yarn start:https`
+    protocol: 'https:',
+    host: 'localhost:4430',
+    api: 'https://croton.cf:4000/api',
+  },
+  localUsingLocalApi: { // local devServer@HTTP using local API, started using `yarn start:local`
+    protocol: 'http:',
+    host: 'localhost:8081',
+    api: 'http://localhost:3000/api',
+  },
+  localUsingLocalApiHttps: { // local devServer@HTTPS using local API, started using `yarn start:local:https`
+    protocol: 'https:',
+    host: 'localhost:4431',
+    api: 'https://localhost:4000/api',
+  },
+  localBuildServe: { // local build statically served using `yarn serve`, using dev env API, HTTP part
     protocol: 'http:',
     host: 'localhost',
     api: 'http://croton.cf:3000/api',
   },
-  localServerHttps: {
+  localBuildServeHttps: { // local build statically served using `yarn serve`, using dev env API, HTTPS part
     protocol: 'https:',
     host: 'localhost',
     api: 'https://croton.cf:4000/api',


### PR DESCRIPTION
Currently by default web start uses the dev environment backend.

It starts on port 8080:
```
"start": "cross-env PORT=8080 react-scripts start",
```

and connects ot a dev environment backend according to the environments config:
```
  local: {
    protocol: 'http:',
    host: 'localhost:8080',
    api: 'http://croton.cf:3000/api',  <<< DEV BE
  },
```

We might want to have another package.json script and a corresponding environmens entry to use when we want to run it against a local backend instead:
```
"start:local": "cross-env PORT=8081 react-scripts start",

  localWithLocalApi: {
    protocol: 'http:',
    host: 'localhost:8081',
    api: 'http://localhost:3000/api',  <<< LOCAL BE
  },
```

P.S. And the same for HTTPS:
```
"start:local": "cross-env HTTPS=true PORT=4431 react-scripts start",

  localWithLocalApiHttps: {
    protocol: 'https:',
    host: 'localhost:4431',
    api: 'https://localhost:4000/api',  <<< LOCAL BE OVER HTTPS
  },
```